### PR TITLE
enum表記・エラーメッセージの日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,4 +75,5 @@ gem 'jquery-rails'
 gem 'ancestry'
 gem 'active_hash'
 gem 'payjp'
-
+gem 'rails-i18n'
+gem 'enum_help'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,8 @@ GEM
     diff-lcs (1.4.3)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.9.0)
     erubis (2.7.0)
     factory_bot (6.0.2)
@@ -227,6 +229,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (6.0.0)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 7)
     railties (6.0.3.2)
       actionpack (= 6.0.3.2)
       activesupport (= 6.0.3.2)
@@ -357,6 +362,7 @@ DEPENDENCIES
   capybara (>= 2.15)
   carrierwave
   devise
+  enum_help
   factory_bot_rails
   faker
   font-awesome-sass
@@ -371,6 +377,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 6.0.0)
   rails-controller-testing
+  rails-i18n
   rspec-rails (~> 4.0.0.beta2)
   sass-rails (~> 5)
   selenium-webdriver

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,12 +18,14 @@ class Item < ApplicationRecord
   validates :trading_status,presence: true
   validates :seller_id,presence: true
 
+  #配送状況
   enum trading_status: { AlreadyDelivered:0,#配送済み
                           InTransit:1,#輸送中
                           InDelivery:2,#配達中
                           Delivered:3,#配達済み
                           InVestigating:4#調査中
                         }
+  #商品の状態
   enum item_condition: { BrandNew:0,#新品、未使用
                         NearUnused:1,#未使用に近い
                         NoNoticeableScratchesOrStains:2,#目立った傷や汚れなし
@@ -31,14 +33,16 @@ class Item < ApplicationRecord
                          ThereAreScratchesAndDirt:4,#傷や汚れあり
                          OverallConditionIsbad:5#全体的に状態が悪い
                         }
- 
+ #配送料の負担
   enum postage_payer: { PostageIncluded:0,#送料込み
                         FreightCollect:1#着払い
                       }
+  #発送までの日数
   enum preparation_day:{ MaxTwo:0,#1~2日で発送
                         MaxThree:1,#2~3日で発送
                         MaxSeven:2#4~7日で発送
                       }
+  #配送の方法
   enum postage_type:{Undecided:0,#未定
                       Courier:1,#宅急便
                       Post:2#郵便

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -204,3 +204,29 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
+  enums:
+    item:
+      trading_status:
+        AlreadyDelivered: "配送済み"
+        InTransit: "輸送中"
+        InDelivery: "配達中"
+        Delivered: "配達済み"
+        InVestigating: 調査中
+      item_condition:
+        BrandNew: 新品、未使用
+        NearUnused: 未使用に近い
+        NoNoticeableScratchesOrStains: 目立った傷や汚れなし
+        SomeScratchesAndDirt: やや傷や汚れあり
+        ThereAreScratchesAndDirt: 傷や汚れあり
+        OverallConditionIsbad: 全体的に状態が悪い
+      postage_payer:
+        PostageIncluded: 送料込み
+        FreightCollect: 着払い
+      preparation_day:
+        MaxTwo: 1~2日で発送
+        MaxThree: 2~3日で発送
+        MaxSeven: 4~7日で発送
+      postage_type:
+        Undecided: 未定
+        Courier: 宅急便
+        Post: 郵便

--- a/spec/factories/sending_destinations.rb
+++ b/spec/factories/sending_destinations.rb
@@ -9,6 +9,6 @@ FactoryBot.define do
     city {"世田谷区"}
     house_number {"11-1"}
     phone_number {"08023451234"}
-    user_id {1}
+    user
   end
 end

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -8,19 +8,19 @@ describe Card do
     it "user_idが無かったら無効" do
       card = build(:card, user_id: nil)
       card.valid?
-      expect(card.errors[:user]).to include("must exist")
+      expect(card.errors[:user]).to include("を入力してください")
     end
 
     it "customer_idが無かったら無効" do
       card = build(:card, customer_id: nil)
       card.valid?
-      expect(card.errors[:customer_id]).to include("can't be blank")
+      expect(card.errors[:customer_id]).to include("を入力してください")
     end
 
     it "card_idが無かったら無効" do
       card = build(:card, card_id: nil)
       card.valid?
-      expect(card.errors[:card_id]).to include("can't be blank")
+      expect(card.errors[:card_id]).to include("を入力してください")
     end
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe User, type: :model do
       it "名前が空白ならばエラー" do
         category = build(:category,name: "")
         category.valid?
-        expect(category.errors[:name]).to include("can't be blank")
+        expect(category.errors[:name]).to include("を入力してください")
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -8,66 +8,65 @@ RSpec.describe Item, type: :model do
       it "nameが空白だとエラー" do
         item = build(:item, name: "")
         item.valid?
-        expect(item.errors[:name]).to include("can't be blank")
+        expect(item.errors[:name]).to include("を入力してください")
       end
 
       it "introductionが空白だとエラー" do
         item = build(:item,introduction: "")
         item.valid?
-        expect(item.errors[:introduction]).to include("can't be blank")
+        expect(item.errors[:introduction]).to include("を入力してください")
       end
 
       it "priceが空白だとエラー" do
         item = build(:item,price: "")
         item.valid?
-        expect(item.errors[:price]).to include("can't be blank")
+        expect(item.errors[:price]).to include("を入力してください")
       end
 
       it "item_conditionが空白だとエラー" do
         item = build(:item,item_condition: "")
         item.valid?
-        expect(item.errors[:item_condition]).to include("can't be blank")
+        expect(item.errors[:item_condition]).to include("を入力してください")
       end
 
       it "postage_payerが空白だとエラー" do
         item = build(:item,postage_payer: "")
         item.valid?
-        expect(item.errors[:postage_payer]).to include("can't be blank")
+        expect(item.errors[:postage_payer]).to include("を入力してください")
       end
 
       it "prefecture_code_idが空白だとエラー" do
         item = build(:item,prefecture_code_id: "")
         item.valid?
-        expect(item.errors[:prefecture_code]).to include("can't be blank")
+        expect(item.errors[:prefecture_code]).to include("を入力してください")
       end
 
       it "preparation_dayが空白だとエラー" do
         item = build(:item,preparation_day: "")
         item.valid?
-        expect(item.errors[:preparation_day]).to include("can't be blank")
+        expect(item.errors[:preparation_day]).to include("を入力してください")
       end
 
       it "category_idが空白だとエラー" do
         item = build(:item,category_id: "")
         item.valid?
-        expect(item.errors[:category]).to include("must exist")
+        expect(item.errors[:category]).to include("を入力してください")
       end
 
       it "trading_statusが空白だとエラー" do
         item = build(:item,trading_status: "")
         item.valid?
-        expect(item.errors[:trading_status]).to include("can't be blank")
+        expect(item.errors[:trading_status]).to include("を入力してください")
       end
 
       it "seller_idが空白だとエラー" do
         item = build(:item,seller_id: "")
         item.valid?
-        expect(item.errors[:seller]).to include("must exist")
+        expect(item.errors[:seller]).to include("を入力してください")
       end
 
       it "全ての条件が合格だったら登録" do
         item = build(:item)
-        binding.pry
         expect(item).to be_valid
       end
     end

--- a/spec/models/sending_destination_spec.rb
+++ b/spec/models/sending_destination_spec.rb
@@ -6,58 +6,53 @@ describe SendingDestination do
     it "送付先氏名の苗字が空白だとエラー" do
       send = build(:sending_destination,destination_first_name: "")
       send.valid?
-      expect(send.errors[:destination_first_name]).to include("can't be blank")
+      expect(send.errors[:destination_first_name]).to include("を入力してください")
     end
     it "送付先氏名の名前が空白だとエラー" do
       send = build(:sending_destination,destination_family_name: "")
       send.valid?
-      expect(send.errors[:destination_family_name]).to include("can't be blank")
+      expect(send.errors[:destination_family_name]).to include("を入力してください")
     end
     it "送付先氏名の苗字のふりがなが空白だとエラー" do
       send = build(:sending_destination,destination_first_name_kana: "")
       send.valid?
-      expect(send.errors[:destination_first_name_kana]).to include("can't be blank")
+      expect(send.errors[:destination_first_name_kana]).to include("を入力してください")
     end
     it "送付先氏名の名前のふりがなが空白だとエラー" do
       send = build(:sending_destination,destination_family_name_kana: "")
       send.valid?
-      expect(send.errors[:destination_family_name_kana]).to include("can't be blank")
+      expect(send.errors[:destination_family_name_kana]).to include("を入力してください")
     end
     it "郵便番号が空白だとエラー" do
       send = build(:sending_destination,post_code: "")
       send.valid?
-      expect(send.errors[:post_code]).to include("can't be blank")
-    end
-    it "電話番号が空白だとエラー" do
-      send = build(:sending_destination,phone_number: "")
-      send.valid?
-      expect(send.errors[:phone_number]).to include("can't be blank")
+      expect(send.errors[:post_code]).to include("を入力してください")
     end
     it "都道府県コードが空白ならエラー" do
       send = build(:sending_destination,prefecture_code: "")
       send.valid?
-      expect(send.errors[:prefecture_code]).to include("can't be blank")
+      expect(send.errors[:prefecture_code]).to include("を入力してください")
     end
     it "市町村が空白ならエラー" do
       send = build(:sending_destination,city: "")
       send.valid?
-      expect(send.errors[:city]).to include("can't be blank")
+      expect(send.errors[:city]).to include("を入力してください")
     end
     it "番地が空白ならエラー" do
       send = build(:sending_destination,house_number: "")
       send.valid?
-      expect(send.errors[:house_number]).to include("can't be blank")
+      expect(send.errors[:house_number]).to include("を入力してください")
     end
     it "重複する電話番号は登録出来ない" do
       send = create(:sending_destination)
       another_send = build(:sending_destination,phone_number: send.phone_number)
       another_send.valid?
-      expect(another_send.errors[:phone_number]).to include("has already been taken")
+      expect(another_send.errors[:phone_number]).to include("はすでに存在します")
     end
     it "郵便番号は7桁の数字でないと登録出来ない。" do
       send = build(:sending_destination,post_code: "000000")
       send.valid?
-      expect(send.errors[:post_code]).to include("is invalid")
+      expect(send.errors[:post_code]).to include("は不正な値です")
     end
     it "すべての条件が合格すると登録可能" do
       send = build(:sending_destination)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -13,28 +13,28 @@ describe User do
     it "ニックネームが空白だとエラー" do
       user = build(:user,nickname: "")
       user.valid?
-      expect(user.errors[:nickname]).to include("can't be blank")
+      expect(user.errors[:nickname]).to include("を入力してください")
     end
     
     it "アドレスが空白だとエラー" do
       user = build(:user,email: "")
       user.valid?
-      expect(user.errors[:email]).to include("can't be blank")
+      expect(user.errors[:email]).to include("を入力してください")
     end
     it "パスワードが空白だとエラー" do
       user = build(:user,password: "")
       user.valid?
-      expect(user.errors[:password]).to include("can't be blank")
+      expect(user.errors[:password]).to include("を入力してください")
     end
     it "パスワードが存在していてもpassword_confirmationが空白だとエラー" do
       user = build(:user, password_confirmation: "")
       user.valid?
-      expect(user.errors[:password_confirmation]).to include("doesn't match Password")
+      expect(user.errors[:password_confirmation]).to include("とパスワードの入力が一致しません")
     end
     it "passwordが６文字以下であればエラー" do
       user = build(:user,password: "000000",password_confirmation:"000000")
       user.valid?
-      expect(user.errors[:password]).to include("is too short (minimum is 7 characters)")
+      expect(user.errors[:password]).to include("は7文字以上で入力してください")
     end
     it "passwordが７文字以上であれば登録できる" do
       user = build(:user,password: "0000000",password_confirmation: "0000000")
@@ -43,53 +43,53 @@ describe User do
     it "first_nameが空白だと登録出来ない" do
       user = build(:user,first_name: "")
       user.valid?
-      expect(user.errors[:first_name]).to include("can't be blank")
+      expect(user.errors[:first_name]).to include("を入力してください")
     end
     it "family_nameが空白だと登録出来ない" do
       user = build(:user,family_name: "")
       user.valid?
-      expect(user.errors[:family_name]).to include("can't be blank")
+      expect(user.errors[:family_name]).to include("を入力してください")
     end
     it "first_name_kanaが空白だと登録出来ない" do
       user = build(:user,first_name_kana: "")
       user.valid?
-      expect(user.errors[:first_name_kana]).to include("can't be blank")
+      expect(user.errors[:first_name_kana]).to include("を入力してください")
     end
     it "family_name_kanaが空白だと登録出来ない" do
       user = build(:user,family_name_kana: "")
       user.valid?
-      expect(user.errors[:family_name_kana]).to include("can't be blank")
+      expect(user.errors[:family_name_kana]).to include("を入力してください")
     end
     it "first_nameが全角以外だと登録出来ない" do
       user = build(:user,first_name: "aaa")
       user.valid?
-      expect(user.errors[:first_name]).to include("is invalid")
+      expect(user.errors[:first_name]).to include("は不正な値です")
     end
     it "family_nameが全角以外だと登録出来ない" do
       user = build(:user,family_name: "aaa")
       user.valid?
-      expect(user.errors[:family_name]).to include("is invalid")
+      expect(user.errors[:family_name]).to include("は不正な値です")
     end
     it "first_name_kanaが全角カナ以外だと登録出来ない" do
       user = build(:user,first_name_kana: "あああ")
       user.valid?
-      expect(user.errors[:first_name_kana]).to include("is invalid")
+      expect(user.errors[:first_name_kana]).to include("は不正な値です")
     end
     it "family_name_kanaが全角カナ以外だと登録出来ない" do
       user = build(:user,family_name_kana: "いいい")
       user.valid?
-      expect(user.errors[:family_name_kana]).to include("is invalid")
+      expect(user.errors[:family_name_kana]).to include("は不正な値です")
     end
     it "birth_dayが空白だと登録出来ない" do
       user = build(:user,birth_day: "")
       user.valid?
-      expect(user.errors[:birth_day]).to include("can't be blank")
+      expect(user.errors[:birth_day]).to include("を入力してください")
     end
     it "重複するアドレスは登録出来ない" do
       user = create(:user)
       another_user = build(:user,email: user.email)
       another_user.valid?
-      expect(another_user.errors[:email]).to include("has already been taken")
+      expect(another_user.errors[:email]).to include("はすでに存在します")
     end
   end
 end

--- a/spec/requests/home_request_spec.rb
+++ b/spec/requests/home_request_spec.rb
@@ -2,11 +2,4 @@ require 'rails_helper'
 
 RSpec.describe "Homes", type: :request do
 
-  describe "GET /index" do
-    it "returns http success" do
-      get "/home/index"
-      expect(response).to have_http_status(:success)
-    end
-  end
-
 end


### PR DESCRIPTION
## What
enumを導入しましたが、このままでは英語表記なので使い勝手が悪い。その為内容を日本語に変換する為の実装を致します。またエラーメッセージについても日本語表記に変更しました。

## Why
英語表記なので使い勝手の悪いサイトになる為、使い勝手の良いサイトにする為に日本語に変換する。