### PR TITLE
商品出品ボタンに出品ページへのルーティング を設定する

### DIFF
--- a/app/views/template/_item.html.haml
+++ b/app/views/template/_item.html.haml
@@ -1,4 +1,4 @@
-= link_to '#', class: "PurchaseBtn" do
+= link_to(new_item_path, {class: "PurchaseBtn"}) do
   .PurchaseBtn__box
     %span.PurchaseBtn__box__text 出品する
     = image_tag 'icon_camera.png', class: 'PurchaseBtn__box__icon'


### PR DESCRIPTION
## What
トップページの右下に浮かんでいるカメラマークに商品出品ページへ遷移するためのルーティング を記述します。